### PR TITLE
removed distinct

### DIFF
--- a/mvi-arch/src/main/java/ru/touchin/roboswag/mvi_arch/core/MviViewModel.kt
+++ b/mvi-arch/src/main/java/ru/touchin/roboswag/mvi_arch/core/MviViewModel.kt
@@ -1,6 +1,7 @@
 package ru.touchin.roboswag.mvi_arch.core
 
 import android.os.Parcelable
+import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.Transformations
@@ -36,7 +37,7 @@ abstract class MviViewModel<NavArgs : Parcelable, Action : ViewAction, State : V
     protected val navArgs: NavArgs = handle.get(MviFragment.INIT_ARGS_KEY) ?: throw IllegalStateException("Nav args mustn't be null")
 
     protected val _state = MutableLiveData(initialState)
-    internal val state = Transformations.distinctUntilChanged(_state)
+    internal val state = _state as LiveData<State>
 
     protected val currentState: State
         get() = state.value ?: initialState


### PR DESCRIPTION
Как ни крути, но будет ситуация, когда внешне экран мог как-то поменяться, минуя вью модель и нужно нарисовать стейт еще раз.

Пример: У нас есть вью стейт, в котором есть поле с текстом ошибки у поля ввода. Есть кастомное поле ввода. У него есть стейт ошибки. Когда пользователь вводит что-то в поле, которое в состоянии ошибки, то ошибка исчезает. Все эти преобразования должны происходить в рамках кастомной вью.

После окончания ввода, оказалось, что пользователь опять допустил ошибку в поле, стейт не поменялся, все так же ошибка, но мы это не нарисуем, т.к distinct скажет что стейт не поменялся, что правда, но это не значит, что на экране ничего не поменялось визуально.