### PR TITLE
added paginator full state if itemList < pageSize

### DIFF
--- a/pagination/src/main/java/ru/touchin/roboswag/pagination/Paginator.kt
+++ b/pagination/src/main/java/ru/touchin/roboswag/pagination/Paginator.kt
@@ -10,7 +10,8 @@ import ru.touchin.roboswag.mvi_arch.marker.ViewState
 
 class Paginator<Item>(
         private val errorHandleMod: ErrorHandleMod,
-        private val loadPage: suspend (Int) -> List<Item>
+        private val loadPage: suspend (Int) -> List<Item>,
+        private val pageSize: Int
 ) : Store<Paginator.Change, Paginator.Effect, Paginator.State>(State.Empty) {
 
     sealed class Change : StateChange {
@@ -89,7 +90,7 @@ class Paginator<Item>(
                     }
                 }
                 is State.NewPageProgress<*> -> {
-                    if (items.isEmpty()) {
+                    if (items.isEmpty() || items.size < pageSize) {
                         State.FullData(currentState.pageCount, currentState.data)
                     } else {
                         State.Data(currentState.pageCount + 1, currentState.data + items)

--- a/pagination/src/main/java/ru/touchin/roboswag/pagination/Paginator.kt
+++ b/pagination/src/main/java/ru/touchin/roboswag/pagination/Paginator.kt
@@ -90,7 +90,7 @@ class Paginator<Item>(
                     }
                 }
                 is State.NewPageProgress<*> -> {
-                    if (items.isEmpty() || items.size < pageSize) {
+                    if (items.size < pageSize) {
                         State.FullData(currentState.pageCount, currentState.data)
                     } else {
                         State.Data(currentState.pageCount + 1, currentState.data + items)


### PR DESCRIPTION
Если при загрузке данных, получен массив меньше, чем размер страницы, то необходимо считать, что данные полностью загружены. Иначе отправляется лишний запрос, в ответе на который приходит пустой массив. 