### PR TITLE
Add "noinspection" to suppress crashlytics outdate warning in order to proceed static analysis

### DIFF
--- a/navigation-new/build.gradle
+++ b/navigation-new/build.gradle
@@ -32,6 +32,8 @@ dependencies {
     implementation "androidx.fragment:fragment:$versions.fragment"
     implementation "androidx.fragment:fragment-ktx:$versions.fragment"
 
+    // TODO: remove it after migration to the Firebase
+    //noinspection OutdatedLibrary
     implementation("com.crashlytics.sdk.android:crashlytics:$versions.crashlytics@aar") {
         transitive = true
     }

--- a/navigation/build.gradle
+++ b/navigation/build.gradle
@@ -28,6 +28,8 @@ dependencies {
 
     implementation "androidx.appcompat:appcompat:$versions.appcompat"
 
+    // TODO: remove it after migration to the Firebase
+    //noinspection OutdatedLibrary
     implementation("com.crashlytics.sdk.android:crashlytics:$versions.crashlytics@aar") {
         transitive = true
     }


### PR DESCRIPTION
Hotfix для починки билдера
![image](https://user-images.githubusercontent.com/25684167/94257753-7ab0a280-ff34-11ea-9012-95939f605a7b.png)
