### PR TITLE
Add open onMainProcessCreate method for descendants usage

### DIFF
--- a/navigation/src/main/java/ru/touchin/roboswag/components/navigation/TouchinApp.java
+++ b/navigation/src/main/java/ru/touchin/roboswag/components/navigation/TouchinApp.java
@@ -57,12 +57,19 @@ public abstract class TouchinApp extends Application {
     @Override
     public void onCreate() {
         super.onCreate();
+
+        if (ProcessKt.isOnMainProcess(this)) {
+            onMainProcessCreate();
+        }
+    }
+
+    protected void onMainProcessCreate() {
         JodaTimeAndroid.init(this);
         if (BuildConfig.DEBUG) {
             enableStrictMode();
             Lc.initialize(new ConsoleLogProcessor(LcLevel.VERBOSE), true);
             LcGroup.UI_LIFECYCLE.disable();
-        } else if (ProcessKt.isOnMainProcess(this)) {
+        } else {
             try {
                 final FirebaseCrashlytics crashlytics = FirebaseCrashlytics.getInstance();
                 crashlytics.setCrashlyticsCollectionEnabled(true);


### PR DESCRIPTION
Вынес всю инициализацию приложения в метод `onMainProcessCreate`, который вызывается только при создании основного процесса. Далее этот метод будет использоваться в наследниках для инициализации библиотек только в главном процессе, в частности библиотеки антифрода от group-ib.