### PR TITLE
UBRD-6128 Fix displaying first day of month in calendar

### DIFF
--- a/recyclerview-calendar/src/main/java/ru/touchin/calendar/CalendarUtils.java
+++ b/recyclerview-calendar/src/main/java/ru/touchin/calendar/CalendarUtils.java
@@ -276,7 +276,7 @@ public final class CalendarUtils {
         final int firstDayInNextMonth = nextMonthFirstDay.getDayOfWeek() - 1;
 
         if (daysLeftInWeek != 0) {
-            calendarItems.add(new CalendarEmptyItem(shift, shift + daysLeftInWeek));
+            calendarItems.add(new CalendarEmptyItem(shift, shift + daysLeftInWeek - 1));
             shift += daysLeftInWeek;
         }
         calendarItems.add(new CalendarHeaderItem(nextMonthFirstDay.getYear(), nextMonthFirstDay.getMonthOfYear() - 1, shift, shift));


### PR DESCRIPTION
[UBRD-6128](https://jira.touchin.ru/browse/UBRD-6128)

Исправил расчет диапазона для `CalendarEmptyItem` в конце месяца, иначе диапазон перекрывался с диапазоном последующего `CalendarHeaderItem`