### PR TITLE
Add recyclerview submit with callback + up version

### DIFF
--- a/recyclerview-adapters/build.gradle
+++ b/recyclerview-adapters/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     constraints {
         implementation("androidx.recyclerview:recyclerview") {
             version {
-                require '1.0.0'
+                require '1.1.0'
             }
         }
         implementation("androidx.core:core-ktx") {

--- a/recyclerview-adapters/src/main/java/ru/touchin/roboswag/recyclerview_adapters/adapters/DelegationListAdapter.kt
+++ b/recyclerview-adapters/src/main/java/ru/touchin/roboswag/recyclerview_adapters/adapters/DelegationListAdapter.kt
@@ -72,6 +72,19 @@ open class DelegationListAdapter<TItem>(config: AsyncDifferConfig<TItem>) : Recy
     fun submitList(list: List<TItem>?) = differ.submitList(list)
 
     /**
+     * Submits a new list to be diffed, and displayed.
+     *
+     * The commit callback can be used to know when the List is committed, but note that it
+     * may not be executed. If List B is submitted immediately after List A, and is
+     * committed directly, the callback associated with List A will not be run.
+     *
+     * @param newList The new List.
+     * @param commitCallback Optional runnable that is executed when the List is committed, if
+     *                       it is committed.
+     */
+    fun submitList(list: List<TItem>?, commitCallback: (() -> Unit)?) = differ.submitList(list, commitCallback)
+
+    /**
      * Same as [submitList] with fast simple remove all items of a previous list
      */
     fun replaceList(list: List<TItem>) {


### PR DESCRIPTION
Вернул метод `submitList` с коллбэком + повысил версию RecyclerView
У нас и так используется версия RecyclerView 1.1.0 из-за подключенного ViewPager2, поэтому имеет смысл использовать его возможности вместо костылей с post после submit