### PR TITLE
fix webview crashes

### DIFF
--- a/webview/src/main/java/ru/touchin/roboswag/webview/web_view/BaseWebView.kt
+++ b/webview/src/main/java/ru/touchin/roboswag/webview/web_view/BaseWebView.kt
@@ -27,7 +27,7 @@ open class BaseWebView @JvmOverloads constructor(
     var onWebViewLoaded: (() -> Unit)? = null
     var onWebViewRepeatButtonClicked: (() -> Unit)? = null
     var onWebViewScrolled: ((WebView, Int, Int) -> Unit)? = null
-    var onCookieLoaded: ((cookies: Map<String, String>) -> Unit)? = null
+    var onCookieLoaded: ((cookies: Map<String, String>?) -> Unit)? = null
 
     var onJsConfirm: (() -> Unit)? = null
     var onJsAlert: (() -> Unit)? = null
@@ -101,7 +101,7 @@ open class BaseWebView @JvmOverloads constructor(
 
     override fun onOverrideUrlLoading(url: String?): Boolean = isRedirectEnable
 
-    override fun onPageCookiesLoaded(cookies: Map<String, String>) {
+    override fun onPageCookiesLoaded(cookies: Map<String, String>?) {
         onCookieLoaded?.invoke(cookies)
     }
 

--- a/webview/src/main/java/ru/touchin/roboswag/webview/web_view/BaseWebView.kt
+++ b/webview/src/main/java/ru/touchin/roboswag/webview/web_view/BaseWebView.kt
@@ -128,12 +128,14 @@ open class BaseWebView @JvmOverloads constructor(
     open fun setWebViewPreferences() {
         binding.webView.apply {
             scrollBarStyle = View.SCROLLBARS_INSIDE_OVERLAY
-            setLayerType(View.LAYER_TYPE_SOFTWARE, null)
+            setLayerType(View.LAYER_TYPE_HARDWARE, null)
             with(settings) {
                 loadsImagesAutomatically = true
                 javaScriptEnabled = true
                 domStorageEnabled = true
                 loadWithOverviewMode = true
+                useWideViewPort = true
+                setInitialScale(1)
             }
         }
     }

--- a/webview/src/main/java/ru/touchin/roboswag/webview/web_view/BaseWebView.kt
+++ b/webview/src/main/java/ru/touchin/roboswag/webview/web_view/BaseWebView.kt
@@ -124,6 +124,12 @@ open class BaseWebView @JvmOverloads constructor(
         binding.webView.onWebViewDisplayedContent = action
     }
 
+    /**
+     * loadWithOverviewMode loads the WebView completely zoomed out
+     * useWideViewPort sets page size to fit screen
+     * setInitialScale(1) prevents horizontal scrolling when
+     * page has horizontal paddings
+     */
     @SuppressLint("SetJavaScriptEnabled")
     open fun setWebViewPreferences() {
         binding.webView.apply {

--- a/webview/src/main/java/ru/touchin/roboswag/webview/web_view/BaseWebView.kt
+++ b/webview/src/main/java/ru/touchin/roboswag/webview/web_view/BaseWebView.kt
@@ -112,8 +112,12 @@ open class BaseWebView @JvmOverloads constructor(
 
     fun getWebView() = binding.webView
 
+    /**
+     * if url is null it changes to empty string
+     * to prevent infinite LOADING state
+     */
     fun loadUrl(url: String?) {
-        binding.webView.loadUrl(url)
+        binding.webView.loadUrl(url ?: String())
     }
 
     fun setState(newState: WebViewLoadingState) {

--- a/webview/src/main/java/ru/touchin/roboswag/webview/web_view/BaseWebView.kt
+++ b/webview/src/main/java/ru/touchin/roboswag/webview/web_view/BaseWebView.kt
@@ -117,7 +117,7 @@ open class BaseWebView @JvmOverloads constructor(
      * to prevent infinite LOADING state
      */
     fun loadUrl(url: String?) {
-        binding.webView.loadUrl(url ?: String())
+        binding.webView.loadUrl(url ?: "")
     }
 
     fun setState(newState: WebViewLoadingState) {

--- a/webview/src/main/java/ru/touchin/roboswag/webview/web_view/BaseWebViewClient.kt
+++ b/webview/src/main/java/ru/touchin/roboswag/webview/web_view/BaseWebViewClient.kt
@@ -4,7 +4,12 @@ import android.graphics.Bitmap
 import android.net.http.SslError
 import android.os.Handler
 import android.os.Looper
-import android.webkit.*
+import android.webkit.CookieManager
+import android.webkit.SslErrorHandler
+import android.webkit.WebResourceError
+import android.webkit.WebResourceRequest
+import android.webkit.WebView
+import android.webkit.WebViewClient
 import androidx.core.os.postDelayed
 
 open class BaseWebViewClient(private val callback: WebViewCallback, private val isSslPinningEnable: Boolean) : WebViewClient() {

--- a/webview/src/main/java/ru/touchin/roboswag/webview/web_view/BaseWebViewClient.kt
+++ b/webview/src/main/java/ru/touchin/roboswag/webview/web_view/BaseWebViewClient.kt
@@ -33,11 +33,17 @@ open class BaseWebViewClient(private val callback: WebViewCallback, private val 
         }
     }
 
+    /**
+     * onPageFinished calls always, but after onReceivedError
+     */
     override fun onPageFinished(view: WebView, url: String) {
         super.onPageFinished(view, url)
         isTimeout = false
         if (!isError) {
             callback.onPageCookiesLoaded(CookieManager.getInstance().getCookie(url).processCookies())
+        }
+        if (url == "about:blank") {
+            isError = true
         }
         pageFinished()
     }
@@ -56,11 +62,13 @@ open class BaseWebViewClient(private val callback: WebViewCallback, private val 
         }
     }
 
+    /**
+     * onReceivedError don't calls when url is "about:blank" (url string isBlank)
+     */
     override fun onReceivedError(view: WebView, request: WebResourceRequest, error: WebResourceError) {
-        if (!(error.errorCode == -10 && "about:blank" == request.url.toString()) || request.url.toString().isBlank()) {
+        if (error.errorCode != -10) {
             isError = true
         }
-        pageFinished()
     }
 
     private fun pageFinished() {

--- a/webview/src/main/java/ru/touchin/roboswag/webview/web_view/BaseWebViewClient.kt
+++ b/webview/src/main/java/ru/touchin/roboswag/webview/web_view/BaseWebViewClient.kt
@@ -4,12 +4,7 @@ import android.graphics.Bitmap
 import android.net.http.SslError
 import android.os.Handler
 import android.os.Looper
-import android.webkit.CookieManager
-import android.webkit.SslErrorHandler
-import android.webkit.WebResourceError
-import android.webkit.WebResourceRequest
-import android.webkit.WebView
-import android.webkit.WebViewClient
+import android.webkit.*
 import androidx.core.os.postDelayed
 
 open class BaseWebViewClient(private val callback: WebViewCallback, private val isSslPinningEnable: Boolean) : WebViewClient() {
@@ -39,8 +34,8 @@ open class BaseWebViewClient(private val callback: WebViewCallback, private val 
     }
 
     /**
-     * onPageFinished вызывается всегда после onReceivedError,
-     * кроме случая, когда в кэше есть страница для ошибки -2 и сначала вызывается onReceivedError
+     * onPageFinished is always called after onReceivedError,
+     * except when there is a error page in the cache and onReceivedError is called first
      */
     override fun onPageFinished(view: WebView, url: String) {
         super.onPageFinished(view, url)
@@ -72,9 +67,7 @@ open class BaseWebViewClient(private val callback: WebViewCallback, private val 
      * onReceivedError isn't called when url is "about:blank" (url string isBlank)
      */
     override fun onReceivedError(view: WebView, request: WebResourceRequest, error: WebResourceError) {
-        if (error.errorCode != -10 || error.errorCode == -2) {
-            isError = true
-        }
+        isError = true
     }
 
     private fun pageFinished() {

--- a/webview/src/main/java/ru/touchin/roboswag/webview/web_view/BaseWebViewClient.kt
+++ b/webview/src/main/java/ru/touchin/roboswag/webview/web_view/BaseWebViewClient.kt
@@ -4,12 +4,7 @@ import android.graphics.Bitmap
 import android.net.http.SslError
 import android.os.Handler
 import android.os.Looper
-import android.webkit.CookieManager
-import android.webkit.SslErrorHandler
-import android.webkit.WebResourceError
-import android.webkit.WebResourceRequest
-import android.webkit.WebView
-import android.webkit.WebViewClient
+import android.webkit.*
 import androidx.core.os.postDelayed
 
 open class BaseWebViewClient(private val callback: WebViewCallback, private val isSslPinningEnable: Boolean) : WebViewClient() {
@@ -41,7 +36,9 @@ open class BaseWebViewClient(private val callback: WebViewCallback, private val 
     override fun onPageFinished(view: WebView, url: String) {
         super.onPageFinished(view, url)
         isTimeout = false
-        callback.onPageCookiesLoaded(CookieManager.getInstance().getCookie(url).processCookies())
+        if (!isError) {
+            callback.onPageCookiesLoaded(CookieManager.getInstance().getCookie(url).processCookies())
+        }
         pageFinished()
     }
 
@@ -60,7 +57,7 @@ open class BaseWebViewClient(private val callback: WebViewCallback, private val 
     }
 
     override fun onReceivedError(view: WebView, request: WebResourceRequest, error: WebResourceError) {
-        if (!(error.errorCode == -10 && "about:blank" == request.url.toString())) {
+        if (!(error.errorCode == -10 && "about:blank" == request.url.toString()) || request.url.toString().isBlank()) {
             isError = true
         }
         pageFinished()
@@ -70,13 +67,13 @@ open class BaseWebViewClient(private val callback: WebViewCallback, private val 
         callback.onStateChanged(if (isError) WebViewLoadingState.ERROR else WebViewLoadingState.LOADED)
     }
 
-    private fun String.processCookies(): Map<String, String> {
+    private fun String?.processCookies(): Map<String, String> {
         val cookiesMap = mutableMapOf<String, String>()
-        this.split(";")
-                .forEach { cookie ->
-                    val splittedCookie = cookie.trim().split("=")
-                    cookiesMap[splittedCookie.first()] = splittedCookie.last()
-                }
+        this?.split(";")
+            ?.forEach { cookie ->
+                val splittedCookie = cookie.trim().split("=")
+                cookiesMap[splittedCookie.first()] = splittedCookie.last()
+            }
         return cookiesMap
     }
 

--- a/webview/src/main/java/ru/touchin/roboswag/webview/web_view/BaseWebViewClient.kt
+++ b/webview/src/main/java/ru/touchin/roboswag/webview/web_view/BaseWebViewClient.kt
@@ -63,7 +63,7 @@ open class BaseWebViewClient(private val callback: WebViewCallback, private val 
     }
 
     /**
-     * onReceivedError don't calls when url is "about:blank" (url string isBlank)
+     * onReceivedError isn't called when url is "about:blank" (url string isBlank)
      */
     override fun onReceivedError(view: WebView, request: WebResourceRequest, error: WebResourceError) {
         if (error.errorCode != -10) {

--- a/webview/src/main/java/ru/touchin/roboswag/webview/web_view/BaseWebViewClient.kt
+++ b/webview/src/main/java/ru/touchin/roboswag/webview/web_view/BaseWebViewClient.kt
@@ -66,7 +66,7 @@ open class BaseWebViewClient(private val callback: WebViewCallback, private val 
      * onReceivedError isn't called when url is "about:blank" (url string isBlank)
      */
     override fun onReceivedError(view: WebView, request: WebResourceRequest, error: WebResourceError) {
-        if (error.errorCode != -10) {
+        if (error.errorCode != -10 || error.errorCode == -2) {
             isError = true
         }
     }

--- a/webview/src/main/java/ru/touchin/roboswag/webview/web_view/BaseWebViewClient.kt
+++ b/webview/src/main/java/ru/touchin/roboswag/webview/web_view/BaseWebViewClient.kt
@@ -4,7 +4,12 @@ import android.graphics.Bitmap
 import android.net.http.SslError
 import android.os.Handler
 import android.os.Looper
-import android.webkit.*
+import android.webkit.CookieManager
+import android.webkit.SslErrorHandler
+import android.webkit.WebResourceError
+import android.webkit.WebResourceRequest
+import android.webkit.WebView
+import android.webkit.WebViewClient
 import androidx.core.os.postDelayed
 
 open class BaseWebViewClient(private val callback: WebViewCallback, private val isSslPinningEnable: Boolean) : WebViewClient() {
@@ -34,16 +39,17 @@ open class BaseWebViewClient(private val callback: WebViewCallback, private val 
     }
 
     /**
-     * onPageFinished calls always, but after onReceivedError
+     * onPageFinished вызывается всегда после onReceivedError,
+     * кроме случая, когда в кэше есть страница для ошибки -2 и сначала вызывается onReceivedError
      */
     override fun onPageFinished(view: WebView, url: String) {
         super.onPageFinished(view, url)
         isTimeout = false
-        if (!isError) {
-            callback.onPageCookiesLoaded(CookieManager.getInstance().getCookie(url).processCookies())
-        }
         if (url == "about:blank") {
             isError = true
+        }
+        if (!isError) {
+            callback.onPageCookiesLoaded(CookieManager.getInstance().getCookie(url).processCookies())
         }
         pageFinished()
     }

--- a/webview/src/main/java/ru/touchin/roboswag/webview/web_view/WebViewCallback.kt
+++ b/webview/src/main/java/ru/touchin/roboswag/webview/web_view/WebViewCallback.kt
@@ -6,6 +6,6 @@ interface WebViewCallback {
 
     fun onOverrideUrlLoading(url: String?): Boolean
 
-    fun onPageCookiesLoaded(cookies: Map<String, String>)
+    fun onPageCookiesLoaded(cookies: Map<String, String>?)
 
 }


### PR DESCRIPTION
- Фикс вылета вебвью если ссылка isBlank или невалидная (выбивает в OnReceivedError), была попытка сохранить куки, а они null, поэтому вылетало

- Фикс дергающегося скролла (проблема не решена полностью, если вызвать onSwipeRefresh, то страница будет немного подёргиваться, т.к. перезагружается), отключение мешающего горизонтального скролла страницы и подгон под размер экрана

- Увеличение производительности сменой на LAYER_TYPE_HARDWARE

- loadUrl: проверка ссылки на null, тогда она становится пустой строкой и в OnPageFinished опрелеляется как "about:blank", после чего отобразится error_layout, иначе при null попадает в бесконечную загрузку

- Фикс пропадающего сообщения об отсутствии интернета (из кэша) на банках, в OnReceivedError вызывалась лишний раз pageFinished() со сменой состояния LOADED в ERROR и перекрытием сообщения error_layout'ом (он сейчас пустой, поэтому просто белый экран), хотя pageFinished() и так вызывается в OnPageFinished и он выполняется всегда, но уже после OnReceivedError (не вызывается если ссылка isBlank), который и должен определять, была ли ошибка загрузки

- Если для сайта (как на банках) в кэше есть страница с сообщением, то в этом случае сначала вызывается OnPageFinished и показывается эта страница, а уже потом вызывается OnReceivedError и не перекрывает его, т.к. в нём pageFinished не вызывается. Если такой страницы нет, то сначала OnReceivedError и установка isError в true, затем OnPageFinished и переход в состояние ERROR с отображением error_layout, таким образом в вебвью не показываются стандартные страницы об ошибках загрузки как в браузере
 
Осталось нарисовать красивый error_layout :-)

https://jira.touchin.ru/browse/BAN-105
https://jira.touchin.ru/browse/BAN-106
https://jira.touchin.ru/browse/BAN-107
