### PR TITLE
Add TextView with ClickableSpan substring

### DIFF
--- a/kotlin-extensions/src/main/java/ru/touchin/extensions/CharSequence.kt
+++ b/kotlin-extensions/src/main/java/ru/touchin/extensions/CharSequence.kt
@@ -1,0 +1,3 @@
+package ru.touchin.extensions
+
+fun CharSequence.indexesOf(substring: String) = Regex(substring).find(this)?.let { it.range.first to it.range.last + 1 }

--- a/utils/build.gradle
+++ b/utils/build.gradle
@@ -1,6 +1,7 @@
 apply from: "../android-configs/lib-config.gradle"
 
 dependencies {
+    implementation project(':kotlin-extensions')
     implementation "androidx.core:core"
     implementation "androidx.annotation:annotation"
 

--- a/utils/src/main/java/ru/touchin/roboswag/components/utils/spans/SpanUtils.kt
+++ b/utils/src/main/java/ru/touchin/roboswag/components/utils/spans/SpanUtils.kt
@@ -8,6 +8,7 @@ import android.text.style.ForegroundColorSpan
 import android.text.style.URLSpan
 import android.text.util.Linkify
 import android.view.View
+import androidx.annotation.ColorInt
 import androidx.core.text.HtmlCompat
 import ru.touchin.extensions.indexesOf
 
@@ -56,7 +57,12 @@ private data class UrlSpanWithBorders(val span: URLSpan, val start: Int, val end
 /**
  * Find substring inside string (for example in TextView) and fill it with ClickableSpan
  */
-fun CharSequence.getClickableSubstring(substring: String, clickAction: () -> Unit, color: Int? = null) = SpannableString(this)
+fun CharSequence.toClickableSubstringText(
+        substring: String,
+        clickAction: () -> Unit,
+        @ColorInt color: Int? = null,
+        isUnderlineText: Boolean = false
+) = SpannableString(this)
         .apply {
             indexesOf(substring)?.let { (startSpan, endSpan) ->
                 setSpan(object : ClickableSpan() {
@@ -66,10 +72,9 @@ fun CharSequence.getClickableSubstring(substring: String, clickAction: () -> Uni
 
                     override fun updateDrawState(ds: TextPaint) {
                         super.updateDrawState(ds)
-                        ds.isUnderlineText = false
+                        ds.isUnderlineText = isUnderlineText
+                        if (color != null) ds.color = color
                     }
                 }, startSpan, endSpan, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
-
-                color?.let { setSpan(ForegroundColorSpan(it), startSpan, endSpan, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE) }
             }
         }

--- a/utils/src/main/java/ru/touchin/roboswag/components/utils/spans/SpanUtils.kt
+++ b/utils/src/main/java/ru/touchin/roboswag/components/utils/spans/SpanUtils.kt
@@ -2,9 +2,14 @@ package ru.touchin.roboswag.components.utils.spans
 
 import android.text.SpannableString
 import android.text.Spanned
+import android.text.TextPaint
+import android.text.style.ClickableSpan
+import android.text.style.ForegroundColorSpan
 import android.text.style.URLSpan
 import android.text.util.Linkify
+import android.view.View
 import androidx.core.text.HtmlCompat
+import ru.touchin.extensions.indexesOf
 
 /**
  * Convert text with 'href' tags and raw links to spanned text with clickable URLSpan.
@@ -47,3 +52,24 @@ private fun SpannableString.getUrlSpans() = getSpans(0, length, URLSpan::class.j
         .map { UrlSpanWithBorders(it, this.getSpanStart(it), this.getSpanEnd(it)) }
 
 private data class UrlSpanWithBorders(val span: URLSpan, val start: Int, val end: Int)
+
+/**
+ * Find substring inside string (for example in TextView) and fill it with ClickableSpan
+ */
+fun CharSequence.getClickableSubstring(substring: String, clickAction: () -> Unit, color: Int? = null) = SpannableString(this)
+        .apply {
+            indexesOf(substring)?.let { (startSpan, endSpan) ->
+                setSpan(object : ClickableSpan() {
+                    override fun onClick(widget: View) {
+                        clickAction.invoke()
+                    }
+
+                    override fun updateDrawState(ds: TextPaint) {
+                        super.updateDrawState(ds)
+                        ds.isUnderlineText = false
+                    }
+                }, startSpan, endSpan, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+
+                color?.let { setSpan(ForegroundColorSpan(it), startSpan, endSpan, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE) }
+            }
+        }

--- a/views/src/main/java/ru/touchin/roboswag/views/ActionTextView.kt
+++ b/views/src/main/java/ru/touchin/roboswag/views/ActionTextView.kt
@@ -1,0 +1,42 @@
+package ru.touchin.roboswag.views
+
+import android.content.Context
+import android.graphics.Color
+import android.util.AttributeSet
+import androidx.appcompat.widget.AppCompatTextView
+import androidx.core.content.withStyledAttributes
+import ru.touchin.roboswag.components.utils.movementmethods.ClickableMovementMethod
+import ru.touchin.roboswag.components.utils.spans.getClickableSubstring
+
+class ActionTextView @JvmOverloads constructor(
+        context: Context,
+        attrs: AttributeSet? = null,
+        defStyleAttr: Int = 0
+) : AppCompatTextView(context, attrs, defStyleAttr) {
+
+    private var onClickAction: () -> Unit = { }
+
+    init {
+        isClickable = false
+        isLongClickable = false
+        highlightColor = Color.TRANSPARENT
+
+        movementMethod = ClickableMovementMethod
+
+        context.withStyledAttributes(attrs, R.styleable.ActionTextView, defStyleAttr, 0) {
+            val actionText = getString(R.styleable.ActionTextView_actionText).orEmpty()
+            val actionColor = getColor(R.styleable.ActionTextView_actionColor, currentTextColor)
+
+            text = text.getClickableSubstring(
+                    substring = actionText,
+                    clickAction = { onClickAction.invoke() },
+                    color = actionColor
+            )
+        }
+    }
+
+    fun setOnActionClickListener(onClickAction: () -> Unit) {
+        this.onClickAction = onClickAction
+    }
+
+}

--- a/views/src/main/java/ru/touchin/roboswag/views/ActionTextView.kt
+++ b/views/src/main/java/ru/touchin/roboswag/views/ActionTextView.kt
@@ -26,11 +26,13 @@ class ActionTextView @JvmOverloads constructor(
         context.withStyledAttributes(attrs, R.styleable.ActionTextView, defStyleAttr, 0) {
             val actionText = getString(R.styleable.ActionTextView_actionText).orEmpty()
             val actionColor = getColor(R.styleable.ActionTextView_actionColor, currentTextColor)
+            val isUnderlineText = getBoolean(R.styleable.ActionTextView_isUnderlineText, false)
 
             text = text.toClickableSubstringText(
                     substring = actionText,
                     clickAction = { onClickAction.invoke() },
-                    color = actionColor
+                    color = actionColor,
+                    isUnderlineText = isUnderlineText
             )
         }
     }

--- a/views/src/main/java/ru/touchin/roboswag/views/ActionTextView.kt
+++ b/views/src/main/java/ru/touchin/roboswag/views/ActionTextView.kt
@@ -6,7 +6,7 @@ import android.util.AttributeSet
 import androidx.appcompat.widget.AppCompatTextView
 import androidx.core.content.withStyledAttributes
 import ru.touchin.roboswag.components.utils.movementmethods.ClickableMovementMethod
-import ru.touchin.roboswag.components.utils.spans.getClickableSubstring
+import ru.touchin.roboswag.components.utils.spans.toClickableSubstringText
 
 class ActionTextView @JvmOverloads constructor(
         context: Context,
@@ -27,7 +27,7 @@ class ActionTextView @JvmOverloads constructor(
             val actionText = getString(R.styleable.ActionTextView_actionText).orEmpty()
             val actionColor = getColor(R.styleable.ActionTextView_actionColor, currentTextColor)
 
-            text = text.getClickableSubstring(
+            text = text.toClickableSubstringText(
                     substring = actionText,
                     clickAction = { onClickAction.invoke() },
                     color = actionColor

--- a/views/src/main/res/values/attrs.xml
+++ b/views/src/main/res/values/attrs.xml
@@ -53,6 +53,7 @@
     <declare-styleable name="ActionTextView">
         <attr name="actionText" format="string"/>
         <attr name="actionColor" format="color"/>
+        <attr name="isUnderlineText" format="boolean"/>
     </declare-styleable>
 
 </resources>

--- a/views/src/main/res/values/attrs.xml
+++ b/views/src/main/res/values/attrs.xml
@@ -50,4 +50,9 @@
         <attr name="stubText" format="string" />
     </declare-styleable>
 
+    <declare-styleable name="ActionTextView">
+        <attr name="actionText" format="string"/>
+        <attr name="actionColor" format="color"/>
+    </declare-styleable>
+
 </resources>


### PR DESCRIPTION
Добавил `View` для упрощения создания `ClickableSpan` у части текста. В параметры `View` передается `actionText` - кликабельная подстрока и `actionColor` - цвет кликабельной подстроки

Пример:
![image](https://user-images.githubusercontent.com/56832972/123377482-d62bc180-d594-11eb-9ade-bcacc64f9f10.png)
