### PR TITLE
fix open browser

### DIFF
--- a/kotlin-extensions/src/main/java/ru/touchin/extensions/Context.kt
+++ b/kotlin-extensions/src/main/java/ru/touchin/extensions/Context.kt
@@ -5,8 +5,11 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 
-fun Context.safeStartActivity(intent: Intent, options: Bundle? = null, resolveFlags: Int = 0): Boolean =
-        packageManager.resolveActivity(intent, resolveFlags)?.let { startActivity(intent, options) } != null
+fun Context.safeStartActivity(intent: Intent, options: Bundle? = null, resolveFlags: Int = 0) =
+        try {
+            startActivity(intent, options)
+        } catch (e: Throwable) {
+        }
 
 fun Context.openBrowser(url: String) = Intent(Intent.ACTION_VIEW)
         .setData(Uri.parse(url))


### PR DESCRIPTION
resolveActivity возвращает null начиня с API level 30. вариант первый - добавить queries. вариант второй - запускать активити без проверки. из-за того, что тут точно открывается только браузер и чтобы не менять сейчас манифест во всех проектах второй вариант кажется оптимальным.

https://stackoverflow.com/questions/62535856/intent-resolveactivity-returns-null-in-api-30