### PR TITLE
Fix initializing KeyboardBehaviorDetector

### DIFF
--- a/mvi-arch/src/main/java/ru/touchin/roboswag/mvi_arch/core/MviKeyboardResizableFragment.kt
+++ b/mvi-arch/src/main/java/ru/touchin/roboswag/mvi_arch/core/MviKeyboardResizableFragment.kt
@@ -9,7 +9,6 @@ import ru.touchin.roboswag.components.utils.hideSoftInput
 import ru.touchin.roboswag.mvi_arch.marker.ViewAction
 import ru.touchin.roboswag.mvi_arch.marker.ViewState
 import ru.touchin.roboswag.navigation_base.activities.OnBackPressedListener
-import ru.touchin.roboswag.navigation_base.keyboard_resizeable.KeyboardBehaviorDetector
 
 // CPD-OFF
 /**
@@ -48,7 +47,6 @@ abstract class MviKeyboardResizableFragment<NavArgs, State, Action, VM>(
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        activity.keyboardBehaviorDetector = KeyboardBehaviorDetector(activity)
 
         view.requestApplyInsets()
         lifecycle.addObserver(activity.keyboardBehaviorDetector as LifecycleObserver)


### PR DESCRIPTION
Убрал инициализацию `keyboardBehaviorDetector` из фрагмента, т.к. получалось, что у нас по одному `detector`'у на каждый фрагмент. Перенес его инициализацию в `SingleActivity` проекта