### PR TITLE
Fix windowlistener when setting permissions

### DIFF
--- a/navigation-base/src/main/java/ru/touchin/roboswag/navigation_base/keyboard_resizeable/KeyboardBehaviorDetector.kt
+++ b/navigation-base/src/main/java/ru/touchin/roboswag/navigation_base/keyboard_resizeable/KeyboardBehaviorDetector.kt
@@ -35,7 +35,7 @@ class KeyboardBehaviorDetector(
         }
     }
 
-    @OnLifecycleEvent(Lifecycle.Event.ON_START)
+    @OnLifecycleEvent(Lifecycle.Event.ON_RESUME)
     fun startDetection() {
         ViewCompat.setOnApplyWindowInsetsListener(view) { _, windowInsets ->
             val bottomInset = windowInsets.systemWindowInsetBottom


### PR DESCRIPTION
```setOnApplyWindowInsetsListener``` перестаёт следить за изменениями, если были запрошены permissions. Решил с установкой слежения в ```onResume``` 