### PR TITLE
Fix keyboard behavior detection after recreating activity with opened keyboard

### DIFF
--- a/mvi-arch/src/main/java/ru/touchin/roboswag/mvi_arch/core/MviKeyboardResizableFragment.kt
+++ b/mvi-arch/src/main/java/ru/touchin/roboswag/mvi_arch/core/MviKeyboardResizableFragment.kt
@@ -59,7 +59,7 @@ abstract class MviKeyboardResizableFragment<NavArgs, State, Action, VM>(
 
     override fun onPause() {
         super.onPause()
-        notifyKeyboardHidden()
+        if (isKeyboardVisible) activity.hideSoftInput()
         if (isHideKeyboardOnBackEnabled) activity.removeOnBackPressedListener(keyboardHideListener)
     }
 
@@ -85,11 +85,6 @@ abstract class MviKeyboardResizableFragment<NavArgs, State, Action, VM>(
             keyboardHideListener = null
             keyboardShowListener = null
         }
-    }
-
-    private fun notifyKeyboardHidden() {
-        if (isKeyboardVisible) onKeyboardHide()
-        isKeyboardVisible = false
     }
 
 }


### PR DESCRIPTION
При смерти и восстновлении процесса (с опцией "Вытеснение фоновых активностей" и открытой клавиатурой) клавиатура старого процесса остается открытой, из-за этого происходит конфликт в keyboardBehaviorDetector и он перестает отслеживать клавиатуру текущего процесса.
Из-за этого возникала ошибка: https://jira.touchin.ru/browse/PET-318

Если же форсировано скрывать клавиатуру в onPause() MviKeyboardResizableFragment, при перезапуске keyboardBehaviorDetector будет корректно отслеживать состояние клавиатуры.