### PR TITLE
Fix navigating back inside nested features

### DIFF
--- a/navigation-cicerone/src/main/java/ru/touchin/roboswag/navigation_cicerone/flow/FlowFragment.kt
+++ b/navigation-cicerone/src/main/java/ru/touchin/roboswag/navigation_cicerone/flow/FlowFragment.kt
@@ -59,7 +59,11 @@ abstract class FlowFragment<TComponent> : Fragment(R.layout.fragment_flow) {
 
     private val exitRouterOnBackPressed = object : OnBackPressedCallback(true) {
         override fun handleOnBackPressed() {
-            router.exit()
+            if (childFragmentManager.backStackEntryCount == 0 && parentFragmentManager.backStackEntryCount != 0) {
+                parentFragmentManager.popBackStack()
+            } else {
+                router.exit()
+            }
         }
     }
 

--- a/navigation-cicerone/src/main/java/ru/touchin/roboswag/navigation_cicerone/flow/FlowFragment.kt
+++ b/navigation-cicerone/src/main/java/ru/touchin/roboswag/navigation_cicerone/flow/FlowFragment.kt
@@ -59,7 +59,10 @@ abstract class FlowFragment<TComponent> : Fragment(R.layout.fragment_flow) {
 
     private val exitRouterOnBackPressed = object : OnBackPressedCallback(true) {
         override fun handleOnBackPressed() {
-            if (childFragmentManager.backStackEntryCount == 0 && parentFragmentManager.backStackEntryCount != 0) {
+            val isFragmentOnTop = childFragmentManager.backStackEntryCount == 0
+            val hasParentFragment = parentFragmentManager.backStackEntryCount != 0
+
+            if (isFragmentOnTop && hasParentFragment) {
                 parentFragmentManager.popBackStack()
             } else {
                 router.exit()


### PR DESCRIPTION
Когда `FlowFragment` является не самым верхнеуровневым фрагментом, методом `router.exti()` отрабатывает неверно. В `SupportAppNavigator` отрабатывает следующее:
```
protected void fragmentBack() {
        if (localStackCopy.size() > 0) {
            fragmentManager.popBackStack();
            localStackCopy.removeLast();
        } else {
            activityBack();
        }
    }
```

Т.е. если в текущий flow-фрагмент не имеет ничего вложенного, то `Activity` будет закрыта. Чтобы этого избежать, добавил проверку на 
1) Является ли текущий фрагмент последним
2) Есть ли у фрагмента, фрагмент родитель
Если да, то просто делаем `popBackStack`, если нет - `router.exit()`