### PR TITLE
Fix/valid error logging for null fields

### DIFF
--- a/api-logansquare/src/main/java/ru/touchin/templates/logansquare/LoganSquareJsonModel.java
+++ b/api-logansquare/src/main/java/ru/touchin/templates/logansquare/LoganSquareJsonModel.java
@@ -22,6 +22,7 @@ package ru.touchin.templates.logansquare;
 import androidx.annotation.Nullable;
 
 import ru.touchin.roboswag.core.log.Lc;
+import ru.touchin.roboswag.core.log.LcGroup;
 import ru.touchin.templates.ApiModel;
 
 /**
@@ -38,7 +39,9 @@ public abstract class LoganSquareJsonModel extends ApiModel {
      */
     protected static void validateNotNull(@Nullable final Object object) throws ValidationException {
         if (object == null) {
-            throw new ValidationException("Not nullable object is null or missed at " + Lc.getCodePoint(null, 1));
+            ValidationException exception = new ValidationException("Not nullable object is null or missed at " + Lc.getCodePoint(null, 1));
+            LcGroup.API_VALIDATION.e(exception, "Invalid item");
+            throw exception;
         }
     }
 

--- a/logging/src/main/java/ru/touchin/roboswag/core/log/ConsoleLogProcessor.java
+++ b/logging/src/main/java/ru/touchin/roboswag/core/log/ConsoleLogProcessor.java
@@ -29,8 +29,6 @@ import android.util.Log;
  */
 public class ConsoleLogProcessor extends LogProcessor {
 
-    private static final int MAX_LOG_LENGTH = 4000;
-
     public ConsoleLogProcessor(@NonNull final LcLevel lclevel) {
         super(lclevel);
     }
@@ -46,18 +44,8 @@ public class ConsoleLogProcessor extends LogProcessor {
     public void processLogMessage(@NonNull final LcGroup group, @NonNull final LcLevel level,
                                   @NonNull final String tag, @NonNull final String message, @Nullable final Throwable throwable) {
         final String messageToLog = normalize(message + (throwable != null ? '\n' + Log.getStackTraceString(throwable) : ""));
-        final int length = messageToLog.length();
-        for (int i = 0; i < length; i++) {
-            int newline = messageToLog.indexOf('\n', i);
-            newline = newline != -1 ? newline : length;
-            do {
-                final int end = Math.min(newline, i + MAX_LOG_LENGTH);
-                Log.println(level.getPriority(), tag, messageToLog.substring(i, end));
-                i = end;
-            }
-            while (i < newline);
-        }
 
+        Log.println(level.getPriority(), tag, messageToLog);
     }
 
 }


### PR DESCRIPTION
https://github.com/TouchInstinct/RoboSwag/pull/235/commits/919445de07bee2db31f6877bcfcf863fb8c01040 – добавил логгирование для проверок на null при валидации модели

https://github.com/TouchInstinct/RoboSwag/pull/235/commits/0f890cbd1ea0775bc01f58a9590bc973c9b7a2d5 — поменял распечатку стектрейса на стандартную (не знаю почему так раньше было)

как было при фильтрации по API_VALIDATION:
![image](https://user-images.githubusercontent.com/1465932/140772134-719fea9e-543c-4869-8ba9-7efbb24be1a7.png)


как было в общем потоке без фильтра:
![newline-not-filtered](https://user-images.githubusercontent.com/1465932/140772245-a663547b-77d0-401a-92a8-d8f4bf2407c5.jpg)


как стало:
![no-newline-filtered](https://user-images.githubusercontent.com/1465932/140772333-c2deaadb-0cee-4f79-b101-7502a7fc245e.jpg)
