### PR TITLE
FragmentKeyboardListenerObserver

### DIFF
--- a/mvi-arch/src/main/java/ru/touchin/roboswag/mvi_arch/core/MviKeyboardResizableFragment.kt
+++ b/mvi-arch/src/main/java/ru/touchin/roboswag/mvi_arch/core/MviKeyboardResizableFragment.kt
@@ -18,6 +18,10 @@ import ru.touchin.roboswag.navigation_base.keyboard_resizeable.OnShowListener
  * Used to detect IME events (show, hide)
  */
 
+@Deprecated(
+        "You have to be inherited from this class to be able to implement keyboard detection",
+        replaceWith = ReplaceWith("fragment.addKeyboardListener")
+)
 abstract class MviKeyboardResizableFragment<NavArgs, State, Action, VM>(
         @LayoutRes layout: Int
 ) : MviFragment<NavArgs, State, Action, VM>(layout)

--- a/navigation-base/src/main/java/ru/touchin/roboswag/navigation_base/keyboard_resizeable/Fragment.kt
+++ b/navigation-base/src/main/java/ru/touchin/roboswag/navigation_base/keyboard_resizeable/Fragment.kt
@@ -1,0 +1,16 @@
+package ru.touchin.roboswag.navigation_base.keyboard_resizeable
+
+import androidx.fragment.app.Fragment
+
+fun Fragment.addKeyboardListener(
+        onShow: OnShowListener? = null,
+        onHide: OnHideListener? = null
+) {
+    lifecycle.addObserver(
+            FragmentKeyboardListenerObserver(
+                    fragment = this,
+                    onShow = onShow,
+                    onHide = onHide
+            )
+    )
+}

--- a/navigation-base/src/main/java/ru/touchin/roboswag/navigation_base/keyboard_resizeable/FragmentKeyboardListenerObserver.kt
+++ b/navigation-base/src/main/java/ru/touchin/roboswag/navigation_base/keyboard_resizeable/FragmentKeyboardListenerObserver.kt
@@ -1,0 +1,33 @@
+package ru.touchin.roboswag.navigation_base.keyboard_resizeable
+
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.OnLifecycleEvent
+import ru.touchin.roboswag.navigation_base.activities.BaseActivity
+
+/**
+ * Observer for adding listeners for activity's keyboardBehaviorDetector with lifecycle awareness
+ */
+class FragmentKeyboardListenerObserver(
+        fragment: Fragment,
+        private val onShow: OnShowListener? = null,
+        private val onHide: OnHideListener? = null
+) : LifecycleObserver {
+
+    private val keyboardDetector = (fragment.requireActivity() as? BaseActivity)
+            ?.keyboardBehaviorDetector
+            ?: error("Fragment must be launched from BaseActivity")
+
+    @OnLifecycleEvent(Lifecycle.Event.ON_START)
+    fun addListener() {
+        onShow?.let(keyboardDetector::addOnShowListener)
+        onHide?.let(keyboardDetector::addOnHideListener)
+    }
+
+    @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
+    fun removeListener() {
+        onShow?.let(keyboardDetector::removeOnShowListener)
+        onHide?.let(keyboardDetector::removeOnHideListener)
+    }
+}

--- a/navigation-base/src/main/java/ru/touchin/roboswag/navigation_base/keyboard_resizeable/KeyboardResizeableFragment.kt
+++ b/navigation-base/src/main/java/ru/touchin/roboswag/navigation_base/keyboard_resizeable/KeyboardResizeableFragment.kt
@@ -9,6 +9,10 @@ import ru.touchin.roboswag.navigation_base.activities.BaseActivity
 import ru.touchin.roboswag.navigation_base.activities.OnBackPressedListener
 import ru.touchin.roboswag.navigation_base.fragments.BaseFragment
 
+@Deprecated(
+        "You have to be inherited from this class to be able to implement keyboard detection",
+        replaceWith = ReplaceWith("fragment.addKeyboardListener")
+)
 abstract class KeyboardResizeableFragment<TActivity : BaseActivity>(
         @LayoutRes layoutRes: Int
 ) : BaseFragment<TActivity>(

--- a/navigation-base/src/main/java/ru/touchin/roboswag/navigation_base/keyboard_resizeable/StatefulKeyboardResizeableFragment.kt
+++ b/navigation-base/src/main/java/ru/touchin/roboswag/navigation_base/keyboard_resizeable/StatefulKeyboardResizeableFragment.kt
@@ -16,6 +16,10 @@ import ru.touchin.roboswag.navigation_base.fragments.StatefulFragment
  * Used to detect IME events (show, hide)
  */
 
+@Deprecated(
+        "You have to be inherited from this class to be able to implement keyboard detection",
+        replaceWith = ReplaceWith("fragment.addKeyboardListener")
+)
 abstract class StatefulKeyboardResizeableFragment<TActivity : BaseActivity, TState : Parcelable>(
         @LayoutRes layoutRes: Int
 ) : StatefulFragment<TActivity, TState>(


### PR DESCRIPTION
`FragmentKeyboardListenerObserver` - класс, который позволяет подписываться на события клавиатуры защищенно относительно жизненного цикла. Такой `Observer` будет заменой для всех `KeyboardResizableFragment`, т.к. убирает необходимость наследоваться от одного класса.