### PR TITLE
Coroutine scope view

### DIFF
--- a/android-configs/app-config.gradle
+++ b/android-configs/app-config.gradle
@@ -3,5 +3,5 @@ apply plugin: 'com.android.application'
 apply from: '../RoboSwag/android-configs/common-config.gradle'
 
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
+apply plugin: 'kotlin-parcelize'
 apply plugin: 'kotlin-kapt'

--- a/lifecycle/src/main/java/ru/touchin/lifecycle/scope/ViewCoroutineScope.kt
+++ b/lifecycle/src/main/java/ru/touchin/lifecycle/scope/ViewCoroutineScope.kt
@@ -1,0 +1,32 @@
+package ru.touchin.lifecycle.scope
+
+import android.view.View
+import kotlinx.coroutines.*
+import ru.touchin.lifecycle.R
+
+val View.viewScope: CoroutineScope
+    get() {
+        val storedScope = getTag(R.string.view_coroutine_scope) as? CoroutineScope
+        if (storedScope != null) return storedScope
+
+        val newScope = ViewCoroutineScope()
+        if (isAttachedToWindow) {
+            addOnAttachStateChangeListener(newScope)
+            setTag(R.string.view_coroutine_scope, newScope)
+        } else {
+            newScope.cancel()
+        }
+
+        return newScope
+    }
+
+private class ViewCoroutineScope : CoroutineScope, View.OnAttachStateChangeListener {
+    override val coroutineContext = SupervisorJob() + Dispatchers.Main
+
+    override fun onViewAttachedToWindow(view: View) = Unit
+
+    override fun onViewDetachedFromWindow(view: View) {
+        coroutineContext.cancel()
+        view.setTag(R.string.view_coroutine_scope, null)
+    }
+}

--- a/lifecycle/src/main/java/ru/touchin/lifecycle/scope/ViewCoroutineScope.kt
+++ b/lifecycle/src/main/java/ru/touchin/lifecycle/scope/ViewCoroutineScope.kt
@@ -1,7 +1,10 @@
 package ru.touchin.lifecycle.scope
 
 import android.view.View
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import ru.touchin.lifecycle.R
 
 val View.viewScope: CoroutineScope

--- a/lifecycle/src/main/res/values/strings.xml
+++ b/lifecycle/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="view_coroutine_scope">view_coroutine_scope</string>
+</resources>

--- a/mvi-arch/build.gradle
+++ b/mvi-arch/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     def fragmentVersion = "1.2.1"
     def lifecycleVersion = "2.2.0"
     def coroutinesVersion = "1.3.7"
-    def daggerVersion = "2.27"
+    def daggerVersion = "2.34"
     def materialDesignVersion = "1.2.0-rc01"
 
     constraints {

--- a/navigation-cicerone/build.gradle
+++ b/navigation-cicerone/build.gradle
@@ -11,7 +11,7 @@ dependencies {
 
     implementation("com.github.valeryponomarenko.componentsmanager:androidx:2.1.0")
 
-    def daggerVersion = "2.27"
+    def daggerVersion = "2.34"
 
     constraints {
         implementation("ru.terrakok.cicerone:cicerone") {


### PR DESCRIPTION
- Плагин `kotlin-android-extensions` - `deprecated`. Используется для предоставления `Parcelize`, поэтому заменил на `kotlin-parcelize` - https://github.com/TouchInstinct/RoboSwag/pull/245/commits/1b994bab0ea74c67880edb39b8dbbbc5889bfadf
- Повысил версию dagger до `2.34`, чтобы сделать ее совместимой с `kotlin 1.5+` - https://github.com/TouchInstinct/RoboSwag/pull/245/commits/902c029a295e7993ca159602529dc5e7cdd3838e
- Добавил кастомный `CoroutineScope` для `View` - https://github.com/TouchInstinct/RoboSwag/pull/245/commits/cab47a058c765f1b63e1a306bbb60b6f4be3a9ba