### PR TITLE
SubmittablePagingAdapter

### DIFF
--- a/recyclerview-adapters/build.gradle
+++ b/recyclerview-adapters/build.gradle
@@ -7,6 +7,8 @@ dependencies {
 
     implementation "androidx.core:core-ktx"
 
+    implementation "androidx.paging:paging-runtime"
+
     constraints {
         implementation("androidx.recyclerview:recyclerview") {
             version {
@@ -16,6 +18,11 @@ dependencies {
         implementation("androidx.core:core-ktx") {
             version {
                 require '1.0.0'
+            }
+        }
+        implementation("androidx.paging:paging-runtime") {
+            version {
+                require '3.0.0-alpha06'
             }
         }
     }

--- a/recyclerview-adapters/src/main/java/ru/touchin/roboswag/recyclerview_adapters/adapters/SubmittablePagingAdapter.kt
+++ b/recyclerview-adapters/src/main/java/ru/touchin/roboswag/recyclerview_adapters/adapters/SubmittablePagingAdapter.kt
@@ -1,0 +1,27 @@
+package ru.touchin.roboswag.recyclerview_adapters.adapters
+
+import androidx.paging.PagingDataAdapter
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.RecyclerView
+
+abstract class SubmittablePagingAdapter<T : Any, VH : RecyclerView.ViewHolder>(private val diffCallback: DiffUtil.ItemCallback<T>):
+        PagingDataAdapter<T, VH>(diffCallback) {
+    /**
+     * [items] list of updated elements
+     * [transform] callback that keeps logic of transformation item based on newItem.
+     * Should return updated element
+     */
+    fun submitList(items: List<T>, transform: T.(newItem: T, payload: Any?) -> T) {
+        items.forEach { newItem ->
+            snapshot().forEachIndexed { index, oldItem ->
+                if (oldItem != null && diffCallback.areItemsTheSame(oldItem, newItem) && !diffCallback.areContentsTheSame(oldItem, newItem)) {
+                    val payload = diffCallback.getChangePayload(oldItem, newItem)
+
+                    oldItem.transform(newItem, payload)
+
+                    notifyItemChanged(index, payload)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Добавил подкласс `PagingDataAdapter` с возможностью  с делать обновление списка элементов.

`PagingDataAdapter` не умеет в локальное обновление данных через обычный `submitList` как у стандартного `Adapter`
[Реализация на основе этого примера](https://medium.com/tech-takeaways/how-to-update-paginated-data-with-the-android-paging-3-library-ef2d8581e77f)

Возможные доработки:
 - перенести сравнение элементов на бэкграунд поток (предполагается, что в `items` передается только те элементы, которые были обновлены, поэтому это не так больно)
 - обновить библиотеку `paging3` до `3.1.0` (сейчас на петшопе используется именно `3.0.0-alpha06`, поэтому использую ее)