### PR TITLE
Add testing utils

### DIFF
--- a/lifecycle-rx/src/main/java/ru/touchin/lifecycle/viewmodel/RxViewModel.kt
+++ b/lifecycle-rx/src/main/java/ru/touchin/lifecycle/viewmodel/RxViewModel.kt
@@ -8,7 +8,7 @@ import androidx.annotation.CallSuper
  */
 open class RxViewModel(
         private val destroyable: BaseDestroyable = BaseDestroyable(),
-        private val liveDataDispatcher: BaseLiveDataDispatcher = BaseLiveDataDispatcher(destroyable)
+        private val liveDataDispatcher: LiveDataDispatcher = BaseLiveDataDispatcher(destroyable)
 ) : ViewModel(), Destroyable by destroyable, LiveDataDispatcher by liveDataDispatcher {
 
     @CallSuper

--- a/lifecycle-rx/src/main/java/ru/touchin/lifecycle/viewmodel/TestableLiveDataDispatcher.kt
+++ b/lifecycle-rx/src/main/java/ru/touchin/lifecycle/viewmodel/TestableLiveDataDispatcher.kt
@@ -1,0 +1,49 @@
+package ru.touchin.lifecycle.viewmodel
+
+import androidx.lifecycle.MutableLiveData
+import io.reactivex.Completable
+import io.reactivex.Flowable
+import io.reactivex.Maybe
+import io.reactivex.Observable
+import io.reactivex.Single
+import io.reactivex.disposables.Disposable
+import ru.touchin.lifecycle.event.ContentEvent
+import ru.touchin.lifecycle.event.Event
+
+class TestableLiveDataDispatcher(
+        private val destroyable: BaseDestroyable = BaseDestroyable()
+) : LiveDataDispatcher, Destroyable by destroyable {
+
+    override fun <T> Flowable<out T>.dispatchTo(liveData: MutableLiveData<ContentEvent<T>>): Disposable {
+        return untilDestroy(
+                { data -> liveData.value = ContentEvent.Success(data) },
+                { throwable -> liveData.value = ContentEvent.Error(throwable, liveData.value?.data) },
+                { liveData.value = ContentEvent.Complete(liveData.value?.data) })
+    }
+
+    override fun <T> Observable<out T>.dispatchTo(liveData: MutableLiveData<ContentEvent<T>>): Disposable {
+        return untilDestroy(
+                { data -> liveData.value = ContentEvent.Success(data) },
+                { throwable -> liveData.value = ContentEvent.Error(throwable, liveData.value?.data) },
+                { liveData.value = ContentEvent.Complete(liveData.value?.data) })
+    }
+
+    override fun <T> Single<out T>.dispatchTo(liveData: MutableLiveData<ContentEvent<T>>): Disposable {
+        return untilDestroy(
+                { data -> liveData.value = ContentEvent.Success(data) },
+                { throwable -> liveData.value = ContentEvent.Error(throwable, liveData.value?.data) })
+    }
+
+    override fun <T> Maybe<out T>.dispatchTo(liveData: MutableLiveData<ContentEvent<T>>): Disposable {
+        return untilDestroy(
+                { data -> liveData.value = ContentEvent.Success(data) },
+                { throwable -> liveData.value = ContentEvent.Error(throwable, liveData.value?.data) },
+                { liveData.value = ContentEvent.Complete(liveData.value?.data) })
+    }
+
+    override fun Completable.dispatchTo(liveData: MutableLiveData<Event>): Disposable {
+        return untilDestroy(
+                { liveData.value = Event.Complete },
+                { throwable -> liveData.value = Event.Error(throwable) })
+    }
+}


### PR DESCRIPTION
1. В RxViewModel тип liveDataDispatcher заменил с BaseLiveDataDispatcher на интерфейс, чтобы можно было удобно подменять эту зависимость. 
2. Добавил TestableLiveDataDispatcher, в котором нет андроидовских классов, чтобы лайвдаты можно было тестировать на JVM, а не эмуляторе 