### PR TITLE
Remove pretty-print dependency from mvi module

### DIFF
--- a/mvi-arch/build.gradle
+++ b/mvi-arch/build.gradle
@@ -28,8 +28,6 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android")
 
-    implementation("com.tylerthrailkill.helpers:pretty-print:2.0.2")
-
     def fragmentVersion = "1.2.1"
     def lifecycleVersion = "2.2.0"
     def coroutinesVersion = "1.3.7"

--- a/mvi-arch/src/main/java/ru/touchin/roboswag/mvi_arch/core/MviViewModel.kt
+++ b/mvi-arch/src/main/java/ru/touchin/roboswag/mvi_arch/core/MviViewModel.kt
@@ -9,8 +9,10 @@ import androidx.lifecycle.Transformations
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.launch
+import ru.touchin.mvi_arch.BuildConfig
 import ru.touchin.roboswag.mvi_arch.marker.ViewAction
 import ru.touchin.roboswag.mvi_arch.marker.ViewState
+import ru.touchin.roboswag.mvi_arch.mediator.LoggingMediator
 import ru.touchin.roboswag.mvi_arch.mediator.MediatorStore
 
 /**
@@ -40,9 +42,7 @@ abstract class MviViewModel<NavArgs : Parcelable, Action : ViewAction, State : V
 
     private val mediatorStore = MediatorStore(
             listOfNotNull(
-//                    Min api 24
-//                    https://github.com/TouchInstinct/RoboSwag/issues/180
-//                    LoggingMediator(this::class.simpleName!!).takeIf { BuildConfig.DEBUG }
+                    LoggingMediator(this::class.simpleName).takeIf { BuildConfig.DEBUG }
             )
     )
 

--- a/mvi-arch/src/main/java/ru/touchin/roboswag/mvi_arch/mediator/LoggingMediator.kt
+++ b/mvi-arch/src/main/java/ru/touchin/roboswag/mvi_arch/mediator/LoggingMediator.kt
@@ -1,13 +1,12 @@
 package ru.touchin.roboswag.mvi_arch.mediator
 
-import com.tylerthrailkill.helpers.prettyprint.pp
 import ru.touchin.roboswag.core.log.Lc
 import ru.touchin.roboswag.mvi_arch.marker.SideEffect
 import ru.touchin.roboswag.mvi_arch.marker.StateChange
 import ru.touchin.roboswag.mvi_arch.marker.ViewAction
 import ru.touchin.roboswag.mvi_arch.marker.ViewState
 
-class LoggingMediator(private val objectName: String) : Mediator {
+class LoggingMediator(private val objectName: String?) : Mediator {
     override fun onEffect(effect: SideEffect) {
         logObject(
                 prefix = "New Effect:\n",
@@ -40,10 +39,6 @@ class LoggingMediator(private val objectName: String) : Mediator {
             prefix: String,
             obj: T
     ) {
-        val builder = StringBuilder()
-        pp(obj = obj, writeTo = builder)
-
-        val prettyOutput = builder.toString()
-        Lc.d("$objectName: $prefix$prettyOutput\n")
+        Lc.d("$objectName: $prefix$obj\n")
     }
 }


### PR DESCRIPTION
Убрал зависимость `pretty-print` в модуле с mvi, так как:
- он не совместим с api < 24 (проблема все еще осталась), и строка, где он использовался вообще была закомменчена
- он добавлял зависимость, которая занимает в apk почти 10 мб
```
+--- com.tylerthrailkill.helpers:pretty-print:2.0.2
    +--- com.ibm.icu:icu4j:63.1
```
<img width="626" alt="Снимок экрана 2022-04-18 в 11 45 09" src="https://user-images.githubusercontent.com/52128976/163784289-ebb27cd0-dbda-4679-b31a-203594ca5a06.png">