### PR TITLE
Fix KeyboardBehaviorDetector

### DIFF
--- a/navigation-base/src/main/java/ru/touchin/roboswag/navigation_base/keyboard_resizeable/KeyboardBehaviorDetector.kt
+++ b/navigation-base/src/main/java/ru/touchin/roboswag/navigation_base/keyboard_resizeable/KeyboardBehaviorDetector.kt
@@ -53,6 +53,12 @@ class KeyboardBehaviorDetector(
 
             if (startNavigationBarHeight == -1) startNavigationBarHeight = bottomInset
 
+            if (startNavigationBarHeight > bottomInset) {
+                // update height if it was initialized incorrectly
+                startNavigationBarHeight = bottomInset
+                listener.invoke(false, windowInsets)
+            }
+
             ViewCompat.onApplyWindowInsets(view, windowInsets)
         }
         ViewCompat.requestApplyInsets(view)


### PR DESCRIPTION
[PET-2763](https://jira.touchin.ru/browse/PET-2763) - появился баг на Петшопе (видимо после обновления material) из-за того, что неправильно срабатывает `KeyboardBehaviorDetector`

В связке "открытая клавиатура" + DNKA + лок/анлок `startNavigationBarHeight` инициализируются, как будто клавиатура изначально открыта, хотя это не так, после чего определение открытой клавиатуры работает противоположно реальности. Добавил фикс для такой ситуации