### PR TITLE
PET-3233: fix KeyboardBehaviorDetector when bottomInset == 0

### DIFF
--- a/navigation-base/src/main/java/ru/touchin/roboswag/navigation_base/keyboard_resizeable/KeyboardBehaviorDetector.kt
+++ b/navigation-base/src/main/java/ru/touchin/roboswag/navigation_base/keyboard_resizeable/KeyboardBehaviorDetector.kt
@@ -53,7 +53,7 @@ class KeyboardBehaviorDetector(
 
             if (startNavigationBarHeight == -1) startNavigationBarHeight = bottomInset
 
-            if (startNavigationBarHeight > bottomInset) {
+            if (startNavigationBarHeight > bottomInset && bottomInset != 0) {
                 // update height if it was initialized incorrectly
                 startNavigationBarHeight = bottomInset
                 listener.invoke(false, windowInsets)


### PR DESCRIPTION
[PET-3233](https://jira.touchin.ru/browse/PET-3233) - Пропадает таббар после разблокировки телефона

Еще небольшой фикс `KeyboardDetector`. На если открыть МП на самсунге, заблокировать и разблокировать отпечатком или СМАРТ-ЧАСАМИ, то `bottomInset` на секунду принимал значение 0 и дальше всё шло не по плану
тестер уже посмотрел

<img width="350" alt="image" src="https://user-images.githubusercontent.com/52128976/179194900-90c47bd9-1b06-4e1c-ad15-40735765505b.png">
