### PR TITLE
Fix memory leak in Fragment.addKeyboardListener()

### DIFF
--- a/navigation-base/src/main/java/ru/touchin/roboswag/navigation_base/keyboard_resizeable/Fragment.kt
+++ b/navigation-base/src/main/java/ru/touchin/roboswag/navigation_base/keyboard_resizeable/Fragment.kt
@@ -2,11 +2,14 @@ package ru.touchin.roboswag.navigation_base.keyboard_resizeable
 
 import androidx.fragment.app.Fragment
 
+/**
+ * Use in [Fragment.onViewCreated] to access [Fragment.getViewLifecycleOwner]
+ */
 fun Fragment.addKeyboardListener(
         onShow: OnShowListener? = null,
         onHide: OnHideListener? = null
 ) {
-    lifecycle.addObserver(
+    viewLifecycleOwner.lifecycle.addObserver(
             FragmentKeyboardListenerObserver(
                     fragment = this,
                     onShow = onShow,


### PR DESCRIPTION
Фикшу утечки памяти на петшопе и большинство было именно из-за этого )

Метод всегда используется в `onViewCreated()`

- При переходе по экранам каждый раз добавляется новый `FragmentKeyboardListenerObserver` и не удаляется, так как объект `lifecycle` один и тот же
- В лямбды обычно клали ссылку на view == утечка всей view фрагмента 😉

Если взять `viewLifecycleOwner`, то все будет корректно очищаться

PS
Теперь если метод использовать в `onCreate()`, то будет краш
Но по идее там его использовать нет смысла
