### PR TITLE
fix unnecessary dependencies in :navigation-view-controller module

### DIFF
--- a/navigation-viewcontroller/build.gradle
+++ b/navigation-viewcontroller/build.gradle
@@ -7,49 +7,17 @@ dependencies {
     implementation project(":logging")
     implementation project(":navigation-base")
 
-    implementation 'androidx.multidex:multidex'
-
-    implementation 'net.danlew:android.joda'
-
     implementation "androidx.appcompat:appcompat"
-
     implementation "androidx.lifecycle:lifecycle-common-java8"
-    implementation "androidx.lifecycle:lifecycle-livedata-ktx"
-
-    implementation("com.crashlytics.sdk.android:crashlytics")
 
     constraints {
-        implementation("androidx.multidex:multidex") {
-            version {
-                require '2.0.1'
-            }
-        }
-
-        implementation("net.danlew:android.joda") {
-            version {
-                require '2.10.2'
-            }
-        }
-
         implementation("androidx.appcompat:appcompat") {
             version {
                 require '1.0.2'
             }
         }
 
-        implementation("com.crashlytics.sdk.android:crashlytics") {
-            version {
-                require '2.10.0'
-            }
-        }
-
         implementation("androidx.lifecycle:lifecycle-common-java8") {
-            version {
-                require '2.2.0'
-            }
-        }
-
-        implementation("androidx.lifecycle:lifecycle-livedata-ktx") {
             version {
                 require '2.2.0'
             }


### PR DESCRIPTION
модуль navigation-viewcontroller унаследовал от давнего общего модуля navigation зависимости, в которых он не нуждается (в основном использовались в классе TouchinApp, который сейчас перешел в модуль base-navigation)

при обновлении крашлитики одна из них стала вызывать краш на старте приложения. `implementation("com.crashlytics.sdk.android:crashlytics")` тянула за собой `io.fabric.sdk`, которая в свою очередь искала сгенерированную плагином строку `"com.crashlytics.android.build_id"`, но при обновлении она сменила название

```
LEGACY_MAPPING_FILE_ID_RESOURCE_NAME = "com.crashlytics.android.build_id";
MAPPING_FILE_ID_RESOURCE_NAME = "com.google.firebase.crashlytics.mapping_file_id"
```

стектрейс ошибки: 

![image](https://user-images.githubusercontent.com/1465932/220182973-fa717907-abf8-4be2-802a-611192388164.png)
